### PR TITLE
Ignore bad encoding in URL

### DIFF
--- a/lib/trouble/middleware.rb
+++ b/lib/trouble/middleware.rb
@@ -18,7 +18,7 @@ module Trouble
       return [400, {}, ['']]
 
     rescue ActionController::BadRequest
-      raise
+      return [400, {}, ['']]
 
     rescue => exception
       logger.fatal [$!.class, $!.message, $!.backtrace[2..5]].join("\n")

--- a/lib/trouble/middleware.rb
+++ b/lib/trouble/middleware.rb
@@ -17,6 +17,9 @@ module Trouble
       raise unless exception.message.include?('invalid %-encoding')
       return [400, {}, ['']]
 
+    rescue ActionController::BadRequest
+      raise
+
     rescue => exception
       logger.fatal [$!.class, $!.message, $!.backtrace[2..5]].join("\n")
       ::Trouble.notify exception

--- a/lib/trouble/version.rb
+++ b/lib/trouble/version.rb
@@ -2,7 +2,7 @@ module Trouble
   module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 0
-    TINY  = 9
+    TINY  = 10
 
     STRING = [MAJOR, MINOR, TINY].compact.join('.')
   end


### PR DESCRIPTION
This ignores non utf-8 encoding in URLs and returns an empty page with error code 400, without notifying Trouble
